### PR TITLE
Use finagle server set for finagle http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This POC is the outcome of https://wiki.hq.tni01.com/display/~phivale/Explore+use+of+finagle+http+client
+
+
 This is a test-bed for carrying out experiments with finagle basics.
 
 There are two main classes:
@@ -21,4 +24,5 @@ Alternately, these can be run directly via sbt args:
 $ sbt "run-main HttpServer"
 $ sbt "run-main HttpClient"
 ```
+
 

--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ You should see the below for client :
 HTTP/1.1 200 OK Content-Length: 0)
 ```
 
-
+Next steps based on this POC
+https://wiki.hq.tni01.com/pages/viewpage.action?pageId=91425061
+https://jira.tendrilinc.com/browse/PAIIN-377

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 This POC is the outcome of https://wiki.hq.tni01.com/display/~phivale/Explore+use+of+finagle+http+client
 
 
-This is a test-bed for carrying out experiments with finagle basics.
+This is a test-bed for carrying out experiments with finagle zookeeper cluster.
 
 There are two main classes:
-* HttpClient
-* HttpServer
+* HttpClient - Connects to a zookeeper cluster using zk client and discovers the service address. Disconnects the zk client and closes the client channel on completion.
+* HttpServer - Registers with a given zookeeper instance. The ip address and port number for the service are published in ZK.
 
 The HttpServer spins up two finagle services using the HTTP codec. These echo a request, emitting messages periodically to stdout.
 
@@ -21,8 +21,20 @@ This will prompt for selecting which main to run.
 
 Alternately, these can be run directly via sbt args:
 ```sh
+$ sbt compile
 $ sbt "run-main HttpServer"
-$ sbt "run-main HttpClient"
+
+Check zk. The service should be registered under services -> Fnagle-HttpServer. A host and port number should be exposed.
+sbt "run-main HttpClient"
+
+You should see something like below for the server : 
+Server on port [10000] Receive count 0
+Server on port [10000] Receive count 1000
+Server on port [10000] Receive count 2000
+
+You should see the below for client :
+(Received response from server ,DefaultHttpResponse(chunked: false)
+HTTP/1.1 200 OK Content-Length: 0)
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,13 @@
-name := "learning-finagle"
+name := "learning-finagle-serverset"
 
 version := "0.1"
 
-scalaVersion := "2.9.2"
+scalaVersion := "2.10.5"
 
-libraryDependencies += "com.twitter" %% "finagle-core" % "6.0.5"
+libraryDependencies ++= Seq(
+  "com.twitter" % "finagle-serversets_2.10" % "6.29.0" ,
+  "com.twitter.finatra" % "finatra-http_2.10" % "2.0.1" ,
+  "com.twitter" % "finagle-httpx_2.10" % "6.29.0" ,
+  "org.apache.logging.log4j" % "log4j-core" % "2.4.1")
 
-libraryDependencies += "com.twitter" %% "finagle-http" % "6.0.5"
+resolvers += "twitter-repo" at "https://maven.twttr.com"

--- a/src/main/scala/HttpClient.scala
+++ b/src/main/scala/HttpClient.scala
@@ -30,7 +30,7 @@ object HttpClient {
     val countdownHook = new AtomicInteger(10000)
 
     Range(0, countdownHook.get()).foreach{i =>
-      val request = new DefaultHttpRequest(HTTP_1_1, GET, "/")
+      val request = new DefaultHttpRequest(HTTP_1_1, GET, "/hello")
       val responseFuture: Future[HttpResponse] = client(request)
       responseFuture.onSuccess {response =>
         val responseCount = countdownHook.decrementAndGet()

--- a/src/main/scala/HttpServer.scala
+++ b/src/main/scala/HttpServer.scala
@@ -24,9 +24,14 @@ class HttpServer(port: Int = 10000) {
   val service: Service[HttpRequest, HttpResponse] = new Service[HttpRequest, HttpResponse] {
     def apply(req: HttpRequest) = {
       val currentCount = requestCount.getAndAdd(1)
+
       if (currentCount % 1000 == 0) {
         println("Server on port [%s] Receive count %s".format(port, currentCount))
+        if (req.getUri().equals("/hello")){
+          println("Hello from server...")
+        }
       }
+
       Future(new DefaultHttpResponse(req.getProtocolVersion, OK))
     }
   }

--- a/src/main/scala/HttpServer.scala
+++ b/src/main/scala/HttpServer.scala
@@ -15,6 +15,8 @@ import scala.collection.JavaConverters._
 object HttpServer {
   def main(args: Array[String]) {
     new HttpServer(10000)
+    new HttpServer(10001)
+    new HttpServer(10003)
    }
 }
 

--- a/src/main/scala/HttpServer.scala
+++ b/src/main/scala/HttpServer.scala
@@ -15,8 +15,7 @@ import scala.collection.JavaConverters._
 object HttpServer {
   def main(args: Array[String]) {
     new HttpServer(10000)
-   // new HttpServer(10001)
-  }
+   }
 }
 
 class HttpServer(port: Int = 10000) {

--- a/src/main/scala/HttpServer.scala
+++ b/src/main/scala/HttpServer.scala
@@ -1,17 +1,21 @@
 import java.net.{InetSocketAddress, SocketAddress}
 import java.util.concurrent.atomic.AtomicInteger
 
+import com.twitter.common.quantity.{Amount, Time}
+import com.twitter.common.zookeeper.{ZooKeeperClient, ServerSetImpl}
 import com.twitter.finagle.Service
 import com.twitter.finagle.builder.{Server, ServerBuilder}
 import com.twitter.finagle.http.Http
+import com.twitter.finagle.zookeeper.ZookeeperServerSetCluster
 import com.twitter.util.Future
 import org.jboss.netty.handler.codec.http.HttpResponseStatus._
 import org.jboss.netty.handler.codec.http.{DefaultHttpResponse, HttpRequest, HttpResponse}
+import scala.collection.JavaConverters._
 
 object HttpServer {
   def main(args: Array[String]) {
     new HttpServer(10000)
-    new HttpServer(10001)
+   // new HttpServer(10001)
   }
 }
 
@@ -26,14 +30,22 @@ class HttpServer(port: Int = 10000) {
       Future(new DefaultHttpResponse(req.getProtocolVersion, OK))
     }
   }
-
-  val address: SocketAddress = new InetSocketAddress(port)
-
+  val address: SocketAddress = new InetSocketAddress("localhost",port)
   val server: Server = ServerBuilder()
     .codec(Http())
     .bindTo(address)
     .name("HttpServer")
     .build(service)
+
+  var zookeeperAddr = new InetSocketAddress("zk1", 2181)
+  val zkaddrlist: List[InetSocketAddress] = List(zookeeperAddr)
+  val timeout = Amount.of(30, Time.MINUTES)
+  val zkClient = new ZooKeeperClient(timeout,  zkaddrlist.asJava)
+  val path="/services/Finagle-HttpServer"
+
+  val serverSet = new ServerSetImpl(zkClient, path)
+  val cluster = new ZookeeperServerSetCluster(serverSet,Some("Finagle-HttpServer"))
+  cluster.join(address)
 
   println("Server started on port %s".format(port))
 }


### PR DESCRIPTION
**Jira Ticket(s)**
https://jira.tendrilinc.com/browse/WIDG-1112

**What was the problem/requirement?**
HTTP Finatra/Finagle server did not register with zookeeper unlike RPC services. The idea is to standarize the ZK registration approach for all the services including finagle http.

**What was the solution?**
Upgraded finagle version to 6.29.
Use ZookeeperServerSetCluster to publish the finagle http endpoint to ZK.
Use finagle ZookeeperClient to connect to the service published in ZK.

Why I did not use ZKAnnouncer and ZKResolver?
Initially I used the new ZKResolver and ZKAnnouncer classes recommended by twitter. But twitter does not have a working example for those. There is missing documentation. The only point of reference is Twitters unit test cases. Since the solution is not adopted on a reasonable scale in the industry it seems unreliable at the moment. We can upgrade in future when it is more pragmatic.

**What is the impact of this change?**
Just a POC for finagle HTTP Server and finagle HTTP client.

**How to test this change.**
Git pull the branch Finagle_ServerSet_POC
sbt compile
sbt "run-main HttpServer"
Check zk. The service should be registered under services -> Fnagle-HttpServer. A host and port number should be exposed.
sbt "run-main HttpClient"

You should see something like below for the server : 
Server on port [10000] Receive count 0
Server on port [10000] Receive count 1000
Server on port [10000] Receive count 2000

You should see the below for client :
(Received response from server ,DefaultHttpResponse(chunked: false)
HTTP/1.1 200 OK Content-Length: 0)